### PR TITLE
Add `arrayPageSize` and paginate long arrays, like Chrome Developer Tools

### DIFF
--- a/demo/client.js
+++ b/demo/client.js
@@ -11,6 +11,9 @@ var obj = {
 }
 obj.self = obj
 obj.arr = [obj, obj, obj]
+obj.longArr = []
+for (i = 0; i < 500; i++) obj.longArr.push(i)
+
 var state = null
 function next() {
   var e = new ObjectExplorer(obj, state)


### PR DESCRIPTION
Long arrays might take too much time to render, so I've introduced a behavior on `getNodeForArray` that creates an object with slices of the original array, paginated similarly to how Chrome does it while doing the same object explorer thing.

I've also updated the example to show that:
<img width="264" alt="screen shot 2018-04-17 at 13 51 31" src="https://user-images.githubusercontent.com/126160/38884622-82d9596e-4246-11e8-99b4-bc8239ead1ec.png">